### PR TITLE
pretix-src should not be a shared volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,7 @@ services:
     volumes:
       - ./pretix.cfg:/etc/pretix/pretix.cfg:ro
       - pretix-data:/data
-      - pretix-src:/pretix/src
-  
+
   db:
     image: postgis/postgis:12-2.5-alpine
     container_name: pretalx-db

--- a/pretix.cfg
+++ b/pretix.cfg
@@ -1,6 +1,6 @@
 [pretix]
 instance_name=eventyay-tickets
-url=localhost
+url=http://localhost
 currency=USD
 ; DO NOT change the following value, it has to be set to the location of the
 ; directory *inside* the docker container


### PR DESCRIPTION
url must include the scheme.

this fixes the docker problems we had with the eventyay-tickets PR #76 ( https://github.com/fossasia/eventyay-tickets/pull/76 )

because the src directory was a shared volume, it contained an old version of the code that was mounted on top of the updated code in the container.

we always want the code in the container.

if there is anything in src that needs to be shared, then it will have to be handled separately, ideally by moving it to data.