### PR TITLE
Docker compose improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - pretalx-db:/var/lib/postgres
     environment:
       POSTGRES_USER: postgres_db_user_changeme
-      POSTGRES_PASSWORD: postgres_db_pwd_chaneme
+      POSTGRES_PASSWORD: postgres_db_pwd_changeme
       POSTGRES_DB: eventyay_db
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     container_name: pretalx-db
     restart: unless-stopped
     volumes:
-      - pretalx-db:/var/lib/mysql
+      - pretalx-db:/var/lib/postgres
     environment:
       POSTGRES_USER: postgres_db_user_changeme
       POSTGRES_PASSWORD: postgres_db_pwd_chaneme

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     container_name: eventyay-talk
     restart: unless-stopped
     depends_on: 
-      - redis
-      - db
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
     environment:
       PRETALX_FILESYSTEM_MEDIA: /public/media
       PRETALX_FILESYSTEM_STATIC: /public/static
@@ -22,8 +24,10 @@ services:
     container_name: eventyay-tickets
     restart: unless-stopped
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     ports:
       - "127.0.0.1:8455:80"
     volumes:
@@ -41,6 +45,11 @@ services:
       POSTGRES_USER: postgres_db_user_changeme
       POSTGRES_PASSWORD: postgres_db_pwd_chaneme
       POSTGRES_DB: eventyay_db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:latest
@@ -48,6 +57,8 @@ services:
     restart: unless-stopped
     volumes: 
       - pretalx-redis:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
 
 volumes:
   pretalx-db:

--- a/pretalx.cfg
+++ b/pretalx.cfg
@@ -6,7 +6,7 @@ logs = /data/logs
 [site]
 ; never run debug in production
 debug = False
-url = localhost
+url = http://localhost
 
 [database]
 backend = postgresql

--- a/pretalx.cfg
+++ b/pretalx.cfg
@@ -10,7 +10,7 @@ url = http://localhost
 
 [database]
 backend = postgresql
-name = eventyay
+name = eventyay_db
 user = posgtres_db_user_changeme
 password = postgres_db_pwd_changeme
 host = pretalx-db

--- a/pretix.cfg
+++ b/pretix.cfg
@@ -16,10 +16,10 @@ timezone=America/Denver
 [database]
 ; Replace postgresql with mysql for MySQL
 backend=postgresql
-name=eventyay
-user=postgress_db_user_changeme
+name=eventyay_db
+user=postgres_db_user_changeme
 ; Replace with the password you chose above
-password=postgress_db_pwd_changeme
+password=postgres_db_pwd_changeme
 ; In most docker setups, 172.17.0.1 is the address of the docker host. Adjust
 ; this to wherever your database is running, e.g. the name of a linked container
 ; or of a mounted MySQL socket.

--- a/pretix.cfg
+++ b/pretix.cfg
@@ -1,6 +1,6 @@
 [pretix]
 instance_name=eventyay-tickets
-url=localhost
+url=http://localhost
 currency=USD
 ; DO NOT change the following value, it has to be set to the location of the
 ; directory *inside* the docker container


### PR DESCRIPTION
- add health checks to db and redis service
- start main service only when db and redis service are healthy and running
- use docker volume for the postgres directory (not the mysql one, which is not used)