### PR TITLE
Fix postgres volume location, fix warning about root, fix timezone problems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,13 +40,13 @@ services:
     container_name: db
     restart: unless-stopped
     volumes:
-      - db:/var/lib/postgres
+      - db:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: postgres_db_user_changeme
       POSTGRES_PASSWORD: postgres_db_pwd_changeme
       POSTGRES_DB: eventyay_db
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+    healthcheck: # TODO why can we not use $POSTGRES_USER and $POSTGRES_DB here, since it is in the env?
+      test: ["CMD-SHELL", 'pg_isready -U postgres_db_user_changeme -d eventyay_db']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/pretix.cfg
+++ b/pretix.cfg
@@ -11,7 +11,13 @@ registration=on
 
 [locale]
 default=en
-timezone=America/Denver
+# The following doesn't really work:
+#timezone=America/Denver
+# because (??) the machines run on UTC time and with this setting
+# celery communication has a time difference, giving: 
+#    eventyay-tickets  | [2024-06-08 22:21:15,313: WARNING/MainProcess] Substantial drift from celery@5f47a4113906 may mean clocks are out of sync.  Current drift is 21600 seconds.  [orig: 2024-06-08 22:21:15.313012 recv: 2024-06-09 04:21:15.310646]
+# which is 6h difference which seems to be the diff between Denver and UTC
+timezone=UTC
 
 [database]
 ; Replace postgresql with mysql for MySQL


### PR DESCRIPTION
* postgres: we need to mount /var/lib/postgresql/data
* root warning: that was introduced with the health check, fixed by passing user/db to healthcheck
* timezone: celery reports 6h difference of send/receive - difference between Denver and UTC